### PR TITLE
fix: JXL圧縮後にサムネイルが消える問題を修正

### DIFF
--- a/packages/frontend/src/components/MkCropperDialog.stories.impl.ts
+++ b/packages/frontend/src/components/MkCropperDialog.stories.impl.ts
@@ -38,7 +38,7 @@ export const Default = {
 		};
 	},
 	args: {
-		imageFile: new File([], 'image.webp', { type: 'image/webp' }),
+		imageFile: new File([], 'image.jxl', { type: 'image/jxl' }),
 		aspectRatio: NaN,
 	},
 	parameters: {

--- a/packages/frontend/src/composables/use-uploader.ts
+++ b/packages/frontend/src/composables/use-uploader.ts
@@ -28,6 +28,7 @@ const THUMBNAIL_SUPPORTED_TYPES = [
 	'image/jpeg',
 	'image/png',
 	'image/webp',
+	'image/jxl',
 	'image/svg+xml',
 	'image/gif',
 ];


### PR DESCRIPTION
## 概要
- use-uploader の THUMBNAIL_SUPPORTED_TYPES に image/jxl を追加
- MkCropperDialog の Storybook ダミー入力を image/jxl / .jxl に更新

## 背景
- 画像圧縮後の MIME が image/jxl になるケースでサムネイル判定から漏れ、item.thumbnail が null になってプレビューが消えていました。

## 確認
- pnpm --filter frontend exec eslint src/composables/use-uploader.ts src/components/MkCropperDialog.stories.impl.ts
- 既存 warning のみ（error なし）