### PR TITLE
feat: mise.toml CIタスクとテスト用Docker Compose環境を追加

### DIFF
--- a/compose.test.yml
+++ b/compose.test.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: test-misskey
       POSTGRES_HOST_AUTH_METHOD: trust
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql
     healthcheck:
       test: "pg_isready -U postgres"
       interval: 5s

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,0 +1,26 @@
+name: misskey-test
+services:
+  postgres:
+    image: postgres:18-alpine
+    ports:
+      - "54312:5432"
+    environment:
+      POSTGRES_DB: test-misskey
+      POSTGRES_HOST_AUTH_METHOD: trust
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: "pg_isready -U postgres"
+      interval: 5s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "56312:6379"
+    tmpfs:
+      - /data
+    healthcheck:
+      test: "redis-cli ping"
+      interval: 5s
+      retries: 20

--- a/mise.toml
+++ b/mise.toml
@@ -33,8 +33,8 @@ description = "Stop and remove test containers"
 run = "docker compose -f compose.test.yml down"
 
 [tasks."ci:setup"]
-description = "Copy test config to .config/"
-run = "cp .github/misskey/test.yml .config/"
+description = "Initialize submodules and copy test config"
+run = ["git submodule update --init", "cp .github/misskey/test.yml .config/"]
 
 [tasks."ci:build"]
 description = "Install dependencies and build for CI"

--- a/mise.toml
+++ b/mise.toml
@@ -85,9 +85,7 @@ description = "Run frontend Cypress E2E tests (requires browser)"
 depends = ["ci:build", "ci:services:up"]
 run = [
   "pnpm exec cypress install",
-  "pnpm start:test &",
-  "pnpm exec wait-on http://localhost:61812",
-  "pnpm exec cypress run --browser chrome",
+  "pnpm exec start-server-and-test 'pnpm start:test' http://localhost:61812 'pnpm exec cypress run --browser chrome'",
 ]
 
 [tasks."ci:test:misskey-js"]

--- a/mise.toml
+++ b/mise.toml
@@ -19,3 +19,109 @@ run = [
   "pnpm run build",
   "pnpm run migrate",
 ]
+
+# =============================================================================
+# CI Tasks
+# =============================================================================
+
+[tasks."ci:services:up"]
+description = "Start PostgreSQL and Redis containers for testing"
+run = "docker compose -f compose.test.yml up -d --wait"
+
+[tasks."ci:services:down"]
+description = "Stop and remove test containers"
+run = "docker compose -f compose.test.yml down"
+
+[tasks."ci:setup"]
+description = "Copy test config to .config/"
+run = "cp .github/misskey/test.yml .config/"
+
+[tasks."ci:build"]
+description = "Install dependencies and build for CI"
+depends = ["ci:setup"]
+run = ["pnpm i --frozen-lockfile", "pnpm build"]
+
+[tasks."ci:lint"]
+description = "Run ESLint on all workspaces"
+depends = ["ci:build"]
+run = """
+failed=0
+for ws in backend frontend frontend-shared frontend-builder frontend-embed icons-subsetter sw misskey-js misskey-bubble-game misskey-reversi; do
+  echo "==> Linting $ws..."
+  pnpm --filter "$ws" run eslint || failed=1
+done
+exit $failed
+"""
+
+[tasks."ci:typecheck"]
+description = "Run type checking on key workspaces"
+depends = ["ci:build"]
+run = """
+failed=0
+for ws in backend frontend sw misskey-js; do
+  echo "==> Typechecking $ws..."
+  pnpm --filter "$ws" run typecheck || failed=1
+done
+exit $failed
+"""
+
+[tasks."ci:test:backend"]
+description = "Run backend unit, e2e, and migration tests sequentially"
+depends = ["ci:build", "ci:services:up"]
+run = [
+  "pnpm --filter backend test-and-coverage",
+  "pnpm --filter backend test-and-coverage:e2e",
+  "MISSKEY_CONFIG_YML=test.yml pnpm --filter backend migrate",
+  "MISSKEY_CONFIG_YML=test.yml pnpm --filter backend check-migrations",
+]
+
+[tasks."ci:test:frontend:unit"]
+description = "Run frontend unit tests"
+depends = ["ci:build"]
+run = "pnpm --filter frontend test-and-coverage"
+
+[tasks."ci:test:frontend:e2e"]
+description = "Run frontend Cypress E2E tests (requires browser)"
+depends = ["ci:build", "ci:services:up"]
+run = [
+  "pnpm exec cypress install",
+  "pnpm start:test &",
+  "pnpm exec wait-on http://localhost:61812",
+  "pnpm exec cypress run --browser chrome",
+]
+
+[tasks."ci:test:misskey-js"]
+description = "Build and test misskey-js"
+depends = ["ci:build"]
+run = "pnpm --filter misskey-js test"
+
+[tasks."ci:locale"]
+description = "Verify locale files"
+depends = ["ci:build"]
+run = ["pnpm --filter i18n build", "pnpm --filter i18n verify"]
+
+[tasks."ci:validate-api"]
+description = "Validate OpenAPI api.json"
+depends = ["ci:build"]
+run = [
+  "pnpm --filter backend generate-api-json",
+  "npx @redocly/cli lint --extends=minimal ./packages/backend/built/api.json",
+]
+
+[tasks."ci:build:production"]
+description = "Test production build"
+depends = ["ci:setup"]
+env = { NODE_ENV = "production" }
+run = ["pnpm i --frozen-lockfile", "pnpm build"]
+
+[tasks.ci]
+description = "Run all CI checks (lint, typecheck, tests) in parallel"
+depends = [
+  "ci:lint",
+  "ci:typecheck",
+  "ci:test:backend",
+  "ci:test:frontend:unit",
+  "ci:test:misskey-js",
+  "ci:locale",
+  "ci:validate-api",
+]


### PR DESCRIPTION
## Summary
- `compose.test.yml` を追加 (PostgreSQL 18 + Redis 7, CI 用ポート 54312/56312)
- `mise.toml` に CI 用タスク (`ci:services:up/down`, `ci:setup`, `ci:build`, `ci:lint`, `ci:typecheck`, `ci:test:*`, `ci:locale`, `ci:validate-api`, `ci:build:production`, `ci` メタタスク) を追加。`mise run ci` で並列実行可能
- PostgreSQL 18 でデータディレクトリ構造が変更されたため、tmpfs のマウント先を `/var/lib/postgresql/data` → `/var/lib/postgresql` に修正
- `ci:setup` で `git submodule update --init` を実行するように修正 (fluent-emojis サブモジュール対応)。GitHub Actions の `actions/checkout` (`submodules: true`) と同じく非再帰での初期化であり、ネストされたサブモジュールは存在しないため `--recursive` は意図的に付けていない
- `ci:test:frontend:e2e` は `start-server-and-test` を用いて `pnpm start:test` の起動・待機・終了処理を一括管理 (GitHub Actions の `cypress-io/github-action` 相当)

## Test plan
- [ ] `mise run ci:services:up` でテスト用コンテナが起動できる
- [ ] `mise run ci:setup` がサブモジュール初期化込みで成功する
- [ ] `mise run ci` で一連の CI タスクが通る
- [ ] `mise run ci:test:frontend:e2e` 終了後にバックエンドプロセスが残らない
- [ ] `mise run ci:services:down` で停止できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
