### PR TITLE
fix: masterブランチのCI失敗を修正（lint・flaky E2Eテスト）

### DIFF
--- a/packages/backend/src/core/ImageProcessingService.ts
+++ b/packages/backend/src/core/ImageProcessingService.ts
@@ -131,5 +131,4 @@ export class ImageProcessingService {
 			type: 'image/jxl',
 		};
 	}
-
 }

--- a/packages/backend/test/e2e/streaming.ts
+++ b/packages/backend/test/e2e/streaming.ts
@@ -172,7 +172,7 @@ describe('Streaming', () => {
 				const fired = await waitFire(
 					ayano, 'homeTimeline',		// ayano:home
 					() => api('notes/create', { text: 'bar', visibility: 'followers', replyId: note.id }, kyoko),	// kyoko posts
-					msg => msg.type === 'note' && msg.body.userId === kyoko.id && msg.body.reply.text === 'foo',
+					msg => msg.type === 'note' && msg.body.userId === kyoko.id && msg.body.replyId === note.id,
 				);
 
 				assert.strictEqual(fired, true);


### PR DESCRIPTION
## What
master ブランチで失敗している CI（[d7f2b5ff2d のチェック](https://github.com/Sigma-project/misskey/commit/d7f2b5ff2da26dd14116c00d5b5ee99a41177a4e)）を修正します。

1. **lint (backend) の失敗**: `packages/backend/src/core/ImageProcessingService.ts:133` で `@stylistic/padded-blocks` エラー（クラスの閉じ括弧前の余分な空行）が発生していたため、空行を削除
2. **E2E tests (backend) の失敗**: `test/e2e/streaming.ts` の flaky テスト修正を upstream から cherry-pick（misskey-dev/misskey@d7ceaa9c88db5234822a5875daca8d1e5faf7c5d / misskey-dev/misskey#17312）

## Why
master への直近のマージ（#5）以降、lint と E2E の2つの CI ジョブが失敗しているため。

- lint は JXL 変換メソッド追加時に混入した空行が原因
- E2E は「フォローしているユーザーの visibility: followers な投稿への返信が流れる」テストの述語が `msg.body.reply.text` をオプショナルチェーンなしで参照しており、リプライ以外の note イベントが届くと TypeError で落ちる flaky なテスト。upstream では `msg.body.replyId === note.id` の比較に修正済み

## Additional info (optional)
- `pnpm exec eslint src/core/ImageProcessingService.ts` でエラー解消を確認済み（残るのは既存の import/order 警告のみで、CI は `--quiet` 実行のため影響なし）
- E2E テストの変更は upstream で検証済みの1行修正のため、本 PR の CI で確認する

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
